### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -48,7 +48,7 @@
     <commons-io-version>1.3.2</commons-io-version>
     <commons-lang-version>2.4</commons-lang-version>
     <commons-logging-version>1.1.1</commons-logging-version>
-    <commons-collections-version>3.2.1</commons-collections-version>
+    <commons-collections-version>3.2.2</commons-collections-version>
     <commons-pool-version>1.5.4</commons-pool-version>
     <commons-dbcp-version>1.3</commons-dbcp-version>
     <cxf-version>2.3.3</cxf-version>

--- a/tests/camel-itest/pom.xml
+++ b/tests/camel-itest/pom.xml
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
